### PR TITLE
Separate secrets from configmaps

### DIFF
--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for bridgit (RDS-NG)
 
 type: application
 
-version: 0.5.0
+version: 0.5.1
 
 appVersion: "1.2.0"

--- a/deployment/charts/templates/connectors/osf/config.yaml
+++ b/deployment/charts/templates/connectors/osf/config.yaml
@@ -4,15 +4,11 @@ metadata:
   name: "{{ .Values.connectors.osf.componentName }}-config"
   namespace: {{ .Values.namespace }}
 data:
-{{- if .Values.createSecrets }}
-  RDS_NETWORK_API_KEY: {{ .Values.server.networkApiKey }}
-{{- end }}
   RDS_CONNECTOR_TARGET: {{ .Values.connectors.osf.targetUrl }}
   RDS_NETWORK_SERVER_ALLOWED_ORIGINS: {{ .Values.server.allowedOrigins }}
   RDS_AUTHORIZATION_OAUTH2_SERVER_HOST: {{ .Values.connectors.osf.oauth2.serverHost }}
   RDS_AUTHORIZATION_OAUTH2_CLIENT_REDIRECT_URL: {{ .Values.server.oauth2.domoRedirectUrl }}
   RDS_AUTHORIZATION_OAUTH2_CLIENT_ID: {{ .Values.connectors.osf.oauth2.clientId }}
-  RDS_AUTHORIZATION_OAUTH2_CLIENT_SECRET: {{ .Values.connectors.osf.oauth2.clientSecret }}
   RDS_NETWORK_CLIENT_SERVER_ADDRESS: {{ .Values.server.address }}
   RDS_GENERAL_DEBUG: {{ .Values.debugLog | quote }}
   RDS_GENERAL_DEBUG_TRACE: {{ .Values.debugTrace | quote }}

--- a/deployment/charts/templates/connectors/osf/deployment.yaml
+++ b/deployment/charts/templates/connectors/osf/deployment.yaml
@@ -35,6 +35,8 @@ spec:
             - configMapRef:
                 name: "{{ .Values.connectors.osf.componentName }}-config"
             - secretRef:
+                name: "{{ .Values.connectors.osf.componentName }}-secret"
+            - secretRef:
                 name: network-api-secret
           volumeMounts:
             {{ if and (hasKey .Values.connectors.osf "logos") (hasKey .Values.connectors.osf.logos "default") (.Files.Get .Values.connectors.osf.logos.default) }}

--- a/deployment/charts/templates/connectors/osf/secret.yaml
+++ b/deployment/charts/templates/connectors/osf/secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.createSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Values.connectors.osf.componentName }}-secret"
+  namespace: {{ .Values.namespace }}
+data:
+  RDS_AUTHORIZATION_OAUTH2_CLIENT_SECRET: {{ .Values.connectors.osf.oauth2.clientSecret }}
+{{- end }}

--- a/deployment/charts/templates/connectors/stub/deployment.yaml
+++ b/deployment/charts/templates/connectors/stub/deployment.yaml
@@ -30,6 +30,8 @@ spec:
             - configMapRef:
                 name: "{{ .Values.connectors.stub.componentName }}-config"
             - secretRef:
+                name: "{{ .Values.connectors.stub.componentName }}-secret"
+            - secretRef:
                 name: network-api-secret
 ---
 apiVersion: v1

--- a/deployment/charts/templates/connectors/stub/secret.yaml
+++ b/deployment/charts/templates/connectors/stub/secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.createSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Values.connectors.stub.componentName }}-secret"
+  namespace: {{ .Values.namespace }}
+type: Opaque
+data:
+  RDS_AUTHORIZATION_OAUTH2_CLIENT_SECRET: {{ .Values.connectors.stub.oauth2.clientSecret }}
+{{- end }}

--- a/deployment/charts/templates/connectors/zenodo/config.yaml
+++ b/deployment/charts/templates/connectors/zenodo/config.yaml
@@ -4,15 +4,11 @@ metadata:
   name: "{{ .Values.connectors.zenodo.componentName }}-config"
   namespace: {{ .Values.namespace }}
 data:
-{{- if .Values.createSecrets }}
-  RDS_NETWORK_API_KEY: {{ .Values.server.networkApiKey }}
-{{- end }}
   RDS_CONNECTOR_TARGET: {{ .Values.connectors.zenodo.targetUrl }}
   RDS_NETWORK_SERVER_ALLOWED_ORIGINS: {{ .Values.server.allowedOrigins }}
   RDS_AUTHORIZATION_OAUTH2_SERVER_HOST: {{ .Values.connectors.zenodo.oauth2.serverHost }}
   RDS_AUTHORIZATION_OAUTH2_CLIENT_REDIRECT_URL: {{ .Values.server.oauth2.domoRedirectUrl }}
   RDS_AUTHORIZATION_OAUTH2_CLIENT_ID: {{ .Values.connectors.zenodo.oauth2.clientId }}
-  RDS_AUTHORIZATION_OAUTH2_CLIENT_SECRET: {{ .Values.connectors.zenodo.oauth2.clientSecret }}
   RDS_NETWORK_CLIENT_SERVER_ADDRESS: {{ .Values.server.address }}
   RDS_GENERAL_DEBUG: {{ .Values.debugLog | quote }}
   RDS_GENERAL_DEBUG_TRACE: {{ .Values.debugTrace | quote }}

--- a/deployment/charts/templates/connectors/zenodo/deployment.yaml
+++ b/deployment/charts/templates/connectors/zenodo/deployment.yaml
@@ -29,6 +29,8 @@ spec:
           - configMapRef:
               name: "{{ .Values.connectors.zenodo.componentName }}-config"
           - secretRef:
+              name: "{{ .Values.connectors.zenodo.componentName }}-secret"
+          - secretRef:
               name: network-api-secret
 
 

--- a/deployment/charts/templates/connectors/zenodo/secret.yaml
+++ b/deployment/charts/templates/connectors/zenodo/secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.createSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Values.connectors.zenodo.componentName }}-secret"
+  namespace: {{ .Values.namespace }}
+type: Opaque
+data:
+  RDS_AUTHORIZATION_OAUTH2_CLIENT_SECRET: {{ .Values.connectors.zenodo.oauth2.clientSecret }}
+{{- end }}

--- a/deployment/charts/templates/server/server-config.yaml
+++ b/deployment/charts/templates/server/server-config.yaml
@@ -19,9 +19,6 @@ data:
     RDS_STORAGE_DATABASE_POSTGRESQL_PORT: {{ default "" .Values.server.storage.postgresql.port | quote }}
     RDS_STORAGE_DATABASE_POSTGRESQL_DATABASE: {{ default "" .Values.server.storage.postgresql.database | quote }}
     RDS_STORAGE_DATABASE_POSTGRESQL_USER: {{ default "" .Values.server.storage.postgresql.user | quote }}
-  {{- if .Values.createSecrets }}
-    RDS_STORAGE_DATABASE_POSTGRESQL_PASSWORD: {{ default "" .Values.server.storage.postgresql.password | quote }}
-  {{- end }}
   {{- end }}
 
   {{- if eq .Values.server.storage.engine "mysql" }}
@@ -29,9 +26,6 @@ data:
     RDS_STORAGE_DATABASE_MYSQL_PORT: {{ default "" .Values.server.storage.mysql.port | quote }}
     RDS_STORAGE_DATABASE_MYSQL_DATABASE: {{ default "" .Values.server.storage.mysql.database | quote }}
     RDS_STORAGE_DATABASE_MYSQL_USER: {{ default "" .Values.server.storage.mysql.user | quote }}
-  {{- if .Values.createSecrets }}
-    RDS_STORAGE_DATABASE_MYSQL_PASSWORD: {{ default "" .Values.server.storage.mysql.password | quote }}
-  {{- end }}
   {{- end }}
 
   {{- if eq .Values.server.storage.engine "mariadb" }}
@@ -39,7 +33,4 @@ data:
     RDS_STORAGE_DATABASE_MARIADB_PORT: {{ default "" .Values.server.storage.mariadb.port | quote }}
     RDS_STORAGE_DATABASE_MARIADB_DATABASE: {{ default "" .Values.server.storage.mariadb.database | quote }}
     RDS_STORAGE_DATABASE_MARIADB_USER: {{ default "" .Values.server.storage.mariadb.user | quote }}
-  {{- if .Values.createSecrets }}
-    RDS_STORAGE_DATABASE_MARIADB_PASSWORD: {{ default "" .Values.server.storage.mariadb.password | quote }}
-  {{- end }}
   {{- end }}

--- a/deployment/charts/templates/server/server-secret.yaml
+++ b/deployment/charts/templates/server/server-secret.yaml
@@ -2,13 +2,22 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: server-secret
-    namespace: {{ .Values.namespace }}
+  name: server-secret
+  namespace: {{ .Values.namespace }}
 type: Opaque
 stringData:
-    {{- range $k, $v := .Values.hosts }}
-    {{- if $v.oauth2.hostSecret }}
-    RDS_{{ $k | upper }}_AUTHORIZATION_OAUTH2_SECRETS_HOST: {{ $v.oauth2.hostSecret | quote }}
-    {{- end }}
-    {{- end }}
+  {{- range $k, $v := .Values.hosts }}
+  {{- if $v.oauth2.hostSecret }}
+  RDS_{{ $k | upper }}_AUTHORIZATION_OAUTH2_SECRETS_HOST: {{ $v.oauth2.hostSecret | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if eq .Values.server.storage.engine "postgresql" }}
+  RDS_STORAGE_DATABASE_POSTGRESQL_PASSWORD: {{ .Values.server.storage.postgresql.password | quote }}
+  {{- end }}
+  {{- if eq .Values.server.storage.engine "mysql" }}
+  RDS_STORAGE_DATABASE_MYSQL_PASSWORD: {{ .Values.server.storage.mysql.password | quote }}
+  {{- end }}
+  {{- if eq .Values.server.storage.engine "mariadb" }}
+  RDS_STORAGE_DATABASE_MARIADB_PASSWORD: {{ .Values.server.storage.mariadb.password | quote }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Move all sensitive data from configmaps to secrets. Secrets are only created if `createSecrets: true`. The preferred way would be to create the secrets in some other way, e.g. with sealed secrets, to prevent writing sensitive data in `values.yaml`.